### PR TITLE
allow spring rule book to be strict and disallow POJO rules

### DIFF
--- a/rulebook-spring/src/test/java/com/deliveredtechnologies/rulebook/spring/StrictSpringAwareRuleBookRunnerTest.java
+++ b/rulebook-spring/src/test/java/com/deliveredtechnologies/rulebook/spring/StrictSpringAwareRuleBookRunnerTest.java
@@ -1,0 +1,46 @@
+package com.deliveredtechnologies.rulebook.spring;
+
+import com.deliveredtechnologies.rulebook.FactMap;
+import com.deliveredtechnologies.rulebook.NameValueReferableMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ContextConfiguration(classes = TestConfig.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class StrictSpringAwareRuleBookRunnerTest {
+  @Autowired
+  @Qualifier("strictSpringRuleBookRunner")
+  private SpringAwareRuleBookRunner _ruleBook;
+
+  private NameValueReferableMap<String> _facts = new FactMap<>();
+
+  @Before
+  public void setUp() {
+    _facts.setValue("value1", "Value");
+    _facts.setValue("value2", "Value");
+  }
+
+
+  @Test(expected = IllegalStateException.class)
+  public void strictRuleBookShouldThrowInvalidStateForPojoRules() {
+    _ruleBook.getRuleInstance(SpringRuleWithoutResult.class);
+  }
+
+  @Test()
+  public void strictRuleBookShouldReturnBeanRuleSuccessfully() {
+    final Object ruleInstance = _ruleBook.getRuleInstance(SpringRuleWithResult.class);
+
+    assertThat(ruleInstance, is(SpringRuleWithResult.class));
+  }
+
+
+}

--- a/rulebook-spring/src/test/java/com/deliveredtechnologies/rulebook/spring/TestConfig.java
+++ b/rulebook-spring/src/test/java/com/deliveredtechnologies/rulebook/spring/TestConfig.java
@@ -3,11 +3,13 @@ package com.deliveredtechnologies.rulebook.spring;
 import com.deliveredtechnologies.rulebook.StandardDecision;
 import com.deliveredtechnologies.rulebook.model.RuleBook;
 import com.deliveredtechnologies.rulebook.model.runner.RuleBookRunner;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 
 import java.io.InvalidClassException;
@@ -24,11 +26,12 @@ public class TestConfig {
 
   /**
    * Creates a RuleBookBean; DSL rules and RuleBean POJO rules can be mixed together.
-   * @return  RuleBean prototype
+   *
+   * @return RuleBean prototype
    */
   @Bean
   @Scope("prototype")
-  public RuleBookBean ruleBookBean()  {
+  public RuleBookBean ruleBookBean() {
     RuleBookBean ruleBookBean = new RuleBookBean();
     try {
       ruleBookBean.addRule(_context.getBean(SpringRuleWithResult.class));
@@ -59,7 +62,15 @@ public class TestConfig {
   }
 
   @Bean
+  @Primary
   public SpringAwareRuleBookRunner springAwareRuleBookRunner() {
     return new SpringAwareRuleBookRunner("com.deliveredtechnologies.rulebook.spring");
+  }
+
+  @Bean("strictSpringRuleBookRunner")
+  public SpringAwareRuleBookRunner strictSpringRuleBookRunner() {
+    final SpringAwareRuleBookRunner springAwareRuleBookRunner = new SpringAwareRuleBookRunner("com.deliveredtechnologies.rulebook.spring");
+    springAwareRuleBookRunner.setAllowNonSpringRules(false);
+    return springAwareRuleBookRunner;
   }
 }


### PR DESCRIPTION
The idea of this feature is to have Spring runners that does not allow POJO rules to be executed.

I currently have a scenario where I only have SpringBeans, and within the execution sometimes one bean fail to initialise due to an error (a `BeanInstantiationException` is thrown) and I don't want a POJO rule because the required underlying services are going to be all `null` and the rule will fail with NPE everywhere.

So if I have a strict runner that does not load POJO rules when one of my rules fails to instantiate in a spring fashion it will at least warn me with a log + exception in my logs.

