### PR TITLE
When ERROR_ON_FAILURE, set new rule status ERROR for rule that fails.

### DIFF
--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/AuditableRule.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/AuditableRule.java
@@ -91,8 +91,14 @@ public class AuditableRule<T, U> implements Rule<T, U>, Auditable {
 
   @Override
   public boolean invoke(NameValueReferableMap facts) {
-    boolean isPassing = _rule.invoke(facts);
-    _auditor.updateRuleStatus(this, isPassing ? RuleStatus.EXECUTED : RuleStatus.SKIPPED);
+    boolean isPassing;
+    try {
+      isPassing = _rule.invoke(facts);
+      _auditor.updateRuleStatus(this, isPassing ? RuleStatus.EXECUTED : RuleStatus.SKIPPED);
+    } catch (RuleException ex) {
+      _auditor.updateRuleStatus(this, RuleStatus.ERROR);
+      throw ex;
+    }
     return isPassing;
   }
 

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/RuleStatus.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/RuleStatus.java
@@ -7,5 +7,6 @@ public enum RuleStatus {
   PENDING,
   SKIPPED,
   EXECUTED,
-  NONE
+  NONE,
+  ERROR
 }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/AuditableRuleTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/AuditableRuleTest.java
@@ -202,4 +202,20 @@ public class AuditableRuleTest {
     Mockito.verify(rule, Mockito.times(1)).setResult(result);
     Mockito.verify(rule, Mockito.times(1)).getResult();
   }
+
+  @Test(expected = RuleException.class)
+  @SuppressWarnings("unchecked")
+  public void auditableRulesWithErrorOnFailureUpdateAuditorToErrorWhenInvokeFails() {
+    Rule<String, String> rule = new GoldenRule(String.class, RuleChainActionType.ERROR_ON_FAILURE);
+    rule.setCondition(facts -> facts.getValue("some fact").equals("nothing"));
+
+    AuditableRule auditableRule = new AuditableRule<String, String>(rule, "Simple rule");
+    Auditor auditor = Mockito.mock(Auditor.class);
+
+    auditableRule.setAuditor(auditor);
+
+    auditableRule.invoke(new FactMap());
+
+    Mockito.verify(auditor, Mockito.times(1)).updateRuleStatus(auditableRule, RuleStatus.ERROR);
+  }
 }

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunnerTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunnerTest.java
@@ -234,7 +234,8 @@ public class RuleBookRunnerTest {
       Assert.assertTrue(err.getCause() instanceof Exception);
       Assert.assertEquals("Sumthin' Broke!", err.getCause().getMessage());
       Assert.assertEquals(ruleBook.getRuleStatus("SampleRule"), RuleStatus.EXECUTED);
-      Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.PENDING);
+      Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.ERROR);
+      Assert.assertEquals(ruleBook.getRuleStatus("AfterErrorRule"), RuleStatus.PENDING);
       return;
     }
     Assert.fail();
@@ -250,7 +251,7 @@ public class RuleBookRunnerTest {
     } catch (RuleException err) {
       Assert.assertTrue(err.getCause() instanceof CustomException);
       Assert.assertEquals("Sumthin' Broke!", err.getCause().getMessage());
-      Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.PENDING);
+      Assert.assertEquals(ruleBook.getRuleStatus("ErrorRule"), RuleStatus.ERROR);
       return;
     }
     Assert.fail();

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/AfterErrorRule.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/test/rulebooks/error/condition/AfterErrorRule.java
@@ -1,0 +1,21 @@
+package com.deliveredtechnologies.rulebook.model.runner.test.rulebooks.error.condition;
+
+import static com.deliveredtechnologies.rulebook.model.RuleChainActionType.ERROR_ON_FAILURE;
+
+import com.deliveredtechnologies.rulebook.annotation.Rule;
+import com.deliveredtechnologies.rulebook.annotation.Then;
+import com.deliveredtechnologies.rulebook.annotation.When;
+
+/**
+ * Created by harshavs on 20/6/19.
+ */
+@Rule(order = 3, ruleChainAction = ERROR_ON_FAILURE)
+public class AfterErrorRule {
+  @When
+  public boolean when() {
+    return true;
+  }
+
+  @Then
+  public void then() {}
+}


### PR DESCRIPTION
Changes for this [issue](https://github.com/deliveredtechnologies/rulebook/issues/164).

Set RuleStatus as ERROR when there is a RuleException. This is useful to identify the rule that failed. Currently, the rule that failed and all other rules not executed have status PENDING making it difficult to identify the errored out rule.