### PR TITLE
RuleAdapter support for unnamed facts of wildcarded collection types

### DIFF
--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapterTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapterTest.java
@@ -10,12 +10,14 @@ import com.deliveredtechnologies.rulebook.NameValueReferable;
 import com.deliveredtechnologies.rulebook.model.GoldenRule;
 import com.deliveredtechnologies.rulebook.model.Rule;
 import com.deliveredtechnologies.rulebook.model.runner.rule.result.ResultRule;
+import com.deliveredtechnologies.rulebook.runner.test.rulebooks.RuleWithWildcardCollections;
 import com.deliveredtechnologies.rulebook.runner.test.rulebooks.SampleRuleWithoutAnnotations;
 import com.deliveredtechnologies.rulebook.runner.test.rulebooks.SampleRuleWithResult;
 import com.deliveredtechnologies.rulebook.runner.test.rulebooks.SampleRuleWithoutRuleAnnotation;
 import com.deliveredtechnologies.rulebook.runner.test.rulebooks.SubRuleWithResult;
 import com.deliveredtechnologies.rulebook.runner.test.rulebooks.SampleRuleWithoutResult;
 
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +38,7 @@ import static org.mockito.Mockito.times;
 /**
  * Tests for {@link RuleAdapter}.
  */
+
 public class RuleAdapterTest {
 
   private FactMap<Object> _factMap;
@@ -293,6 +296,26 @@ public class RuleAdapterTest {
 
     verify(consumer, times(1)).accept(any(FactMap.class));
     Assert.assertTrue(consumer == ((List<Object>)ruleAdapter.getActions()).get(0));
+  }
+
+  @Test
+  public void pojoeWithWildCardCollections() throws InvalidClassException {
+    RuleWithWildcardCollections<Number> rule = new RuleWithWildcardCollections<>();
+    RuleAdapter ruleAdapter = new RuleAdapter(rule);
+    Fact<String> testStringFact = new Fact("stringFactName", "A string value");
+    Fact<String> testStringFact2 = new Fact("secondStringFactName", "A different string value");
+    Fact<Integer> testIntegerFact = new Fact("integerFactName", Integer.MAX_VALUE);
+    Fact<Long> testLongFact = new Fact("longFactName", Long.MAX_VALUE);
+    ruleAdapter.addFacts(testStringFact, testStringFact2, testIntegerFact, testLongFact);
+    ruleAdapter.invoke();
+    Set<CharSequence> stringResults = (Set<CharSequence>)ruleAdapter.getResult().get().getValue();
+    List<Number> numbers = rule._numberSet;
+    Assert.assertEquals(2, numbers.size());
+    Assert.assertTrue(numbers.contains(testIntegerFact.getValue()));
+    Assert.assertTrue(numbers.contains(testLongFact.getValue()));
+    Assert.assertEquals(2, stringResults.size());
+    Assert.assertTrue(stringResults.contains(testStringFact.getValue()));
+    Assert.assertTrue(stringResults.contains(testStringFact2.getValue()));
   }
 
   @Test

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapterTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/model/runner/RuleAdapterTest.java
@@ -299,7 +299,7 @@ public class RuleAdapterTest {
   }
 
   @Test
-  public void pojoeWithWildCardCollections() throws InvalidClassException {
+  public void pojoWithWildCardCollections() throws InvalidClassException {
     RuleWithWildcardCollections<Number> rule = new RuleWithWildcardCollections<>();
     RuleAdapter ruleAdapter = new RuleAdapter(rule);
     Fact<String> testStringFact = new Fact("stringFactName", "A string value");

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/RuleBookRunnerTest.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/RuleBookRunnerTest.java
@@ -19,7 +19,7 @@ public class RuleBookRunnerTest {
     RuleBookRunner ruleBookRunner = spy(new RuleBookRunner("com.deliveredtechnologies.rulebook.runner.test.rulebooks"));
     ruleBookRunner.run();
 
-    verify(ruleBookRunner, times(4)).addRule(any(RuleAdapter.class));
+    verify(ruleBookRunner, times(5)).addRule(any(RuleAdapter.class));
   }
 
   @Test

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/RuleWithWildcardCollections.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/RuleWithWildcardCollections.java
@@ -1,0 +1,30 @@
+package com.deliveredtechnologies.rulebook.runner.test.rulebooks;
+
+import com.deliveredtechnologies.rulebook.RuleState;
+import com.deliveredtechnologies.rulebook.annotation.Given;
+import com.deliveredtechnologies.rulebook.annotation.Result;
+import com.deliveredtechnologies.rulebook.annotation.Rule;
+import com.deliveredtechnologies.rulebook.annotation.Then;
+import java.util.List;
+import java.util.Set;
+
+
+
+@Rule
+public class RuleWithWildcardCollections<T extends Number> {
+
+  @Given
+  public Set<? extends CharSequence> _charSequenceSet;
+
+  @Given
+  public List<T> _numberSet;
+
+  @Result
+  Set<? extends CharSequence> _result;
+
+  @Then
+  public RuleState then() {
+    _result = _charSequenceSet;
+    return RuleState.NEXT;
+  }
+}

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/SubRuleWithResult.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/SubRuleWithResult.java
@@ -1,7 +1,10 @@
 package com.deliveredtechnologies.rulebook.runner.test.rulebooks;
 
+import com.deliveredtechnologies.rulebook.RuleState;
 import com.deliveredtechnologies.rulebook.annotation.Given;
 import com.deliveredtechnologies.rulebook.annotation.When;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by clong on 3/12/17.

--- a/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/SubRuleWithResult.java
+++ b/rulebook-core/src/test/java/com/deliveredtechnologies/rulebook/runner/test/rulebooks/SubRuleWithResult.java
@@ -1,10 +1,7 @@
 package com.deliveredtechnologies.rulebook.runner.test.rulebooks;
 
-import com.deliveredtechnologies.rulebook.RuleState;
 import com.deliveredtechnologies.rulebook.annotation.Given;
 import com.deliveredtechnologies.rulebook.annotation.When;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Created by clong on 3/12/17.


### PR DESCRIPTION
Unnamed `@Given` fields in a POJO rule that are a collection type try to collect any unnamed facts of compatible types and add them to the collection.  But if the field is genericized to a wildcard type (like `Set<? extends Number>`), it was hitting a ClassCastException attempting to hard-cast the parameter to `Class<?>` rather than `WildCardType` or `TypeVariable` as appropriate. This will now identify eligible wildcard types for those wildcarded collections as well.