### PR TITLE
Instantiate Reflections object as-needed. Fix for #155.

### DIFF
--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/Result.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/Result.java
@@ -12,7 +12,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * and across other objects (i.e. DecisionBook and Decision objects)
  */
 public class Result<T> implements Referable<T> {
-  private Map<Long, T> _valueMap = new HashMap<>();
+  private final Map<Long, T> _valueMap = new HashMap<>();
   private final ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
   private T _defaultValue = null;
 

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/Auditor.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/Auditor.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
  */
 public abstract class Auditor {
   protected Map<String, Map<Long, RuleStatus>> _auditMap = new HashMap<>();
-  private ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
+  private final ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
 
   /**
    * Registers a rule to be audited.

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunner.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunner.java
@@ -28,7 +28,7 @@ public class RuleBookRunner extends AbstractRuleBookRunner {
   private String _package;
   private Predicate<String> _subPkgMatch;
   private Class<? extends RuleBook> _prototypeClass;
-  private ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
+  private final ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
   private Optional<List<Class<?>>> _rules = Optional.ofNullable(null);
 
   @SuppressWarnings("unchecked")

--- a/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunner.java
+++ b/rulebook-core/src/main/java/com/deliveredtechnologies/rulebook/model/runner/RuleBookRunner.java
@@ -78,8 +78,6 @@ public class RuleBookRunner extends AbstractRuleBookRunner {
    * @return  a List of POJO Rules
    */
   protected List<Class<?>> getPojoRules() {
-    Reflections reflections = new Reflections(_package);
-
     _lock.readLock().lock();
     try {
       if (_rules.isPresent()) {
@@ -93,6 +91,7 @@ public class RuleBookRunner extends AbstractRuleBookRunner {
       if (_rules.isPresent()) {
         return _rules.get();
       }
+      Reflections reflections = new Reflections(_package);
       List<Class<?>> rules = reflections
           .getTypesAnnotatedWith(com.deliveredtechnologies.rulebook.annotation.Rule.class).stream()
           .filter(rule -> rule.getAnnotatedSuperclass() != null) // Include classes only, exclude interfaces, etc.
@@ -102,9 +101,9 @@ public class RuleBookRunner extends AbstractRuleBookRunner {
       rules.sort(comparingInt(aClass ->
           getAnnotation(com.deliveredtechnologies.rulebook.annotation.Rule.class, aClass).order()));
       _rules = Optional.of(rules);
+      return _rules.get();
     } finally {
       _lock.writeLock().unlock();
     }
-    return _rules.get();
   }
 }


### PR DESCRIPTION
Existing code always creates a `Reflections` object that scans the packages.  The pull request limits the object creation to once, inside of the write lock.

Also enforces the best practice of only accessing the `_rules` field when holding a lock.